### PR TITLE
Goturn 0.1 vgg16

### DIFF
--- a/goturn/loader/loader_imagenet.py
+++ b/goturn/loader/loader_imagenet.py
@@ -130,9 +130,9 @@ class loader_imagenet:
             random_ann.disp_height = 375
             random_ann.disp_width = 500
 
-	print("random_ann.image_path: ", random_ann.image_path)
-	print("imagenet folder: ", self.imagenet_folder)
-	print("img_path: ", img_path)
+	#print("random_ann.image_path: ", random_ann.image_path)
+	#print("imagenet folder: ", self.imagenet_folder)
+	#print("img_path: ", img_path)
         image = cv2.imread(img_path)
 
         img_height = image.shape[0]

--- a/goturn/loader/loader_imagenet.py
+++ b/goturn/loader/loader_imagenet.py
@@ -130,7 +130,9 @@ class loader_imagenet:
             random_ann.disp_height = 375
             random_ann.disp_width = 500
 
-
+	print("random_ann.image_path: ", random_ann.image_path)
+	print("imagenet folder: ", self.imagenet_folder)
+	print("img_path: ", img_path)
         image = cv2.imread(img_path)
 
         img_height = image.shape[0]

--- a/goturn/network/regressor.py
+++ b/goturn/network/regressor.py
@@ -118,7 +118,77 @@ class regressor:
             if self.solver_file:
                 self.solver = caffe.SGDSolver(self.solver_file)
                 net = self.solver.net
-                net.copy_from(caffe_model)
+                #net.copy_from(caffe_model)
+
+                ## Assigning the weight from vgg16 pretrained layer to vgg16 feature extractor parallel layers
+                VGG16net = caffe.Net('vgg16 protofile', caffe_model, caffe.TEST)
+                #W = net.params['con_1'][0].data[...]
+                #b = net.params['con_1'][1].data[...]
+                #net = caffe.Net('path/to/conv2.prototxt', 'path/to/conv2.caffemodel', caffe.TEST)
+
+                net.params['conv1_1'][0].data[...] = VGG16net.params['conv1_1'][0].data[...]
+                net.params['conv1_1'][1].data[...] = VGG16net.params['conv1_1'][1].data[...]
+                net.params['conv1_2'][0].data[...] = VGG16net.params['conv1_2'][0].data[...]
+                net.params['conv1_2'][1].data[...] = VGG16net.params['conv1_2'][1].data[...]
+
+                net.params['conv2_1'][0].data[...] = VGG16net.params['conv2_1'][0].data[...]
+                net.params['conv2_1'][1].data[...] = VGG16net.params['conv2_1'][1].data[...]
+                net.params['conv2_2'][0].data[...] = VGG16net.params['conv2_2'][0].data[...]
+                net.params['conv2_2'][1].data[...] = VGG16net.params['conv2_2'][1].data[...]
+
+                net.params['conv3_1'][0].data[...] = VGG16net.params['conv3_1'][0].data[...]
+                net.params['conv3_1'][1].data[...] = VGG16net.params['conv3_1'][1].data[...]
+                net.params['conv3_2'][0].data[...] = VGG16net.params['conv3_2'][0].data[...]
+                net.params['conv3_2'][1].data[...] = VGG16net.params['conv3_2'][1].data[...]
+                net.params['conv3_3'][0].data[...] = VGG16net.params['conv3_3'][0].data[...]
+                net.params['conv3_3'][1].data[...] = VGG16net.params['conv3_3'][1].data[...]
+
+                net.params['conv4_1'][0].data[...] = VGG16net.params['conv4_1'][0].data[...]
+                net.params['conv4_1'][1].data[...] = VGG16net.params['conv4_1'][1].data[...]
+                net.params['conv4_2'][0].data[...] = VGG16net.params['conv4_2'][0].data[...]
+                net.params['conv4_2'][1].data[...] = VGG16net.params['conv4_2'][1].data[...]
+                net.params['conv4_3'][0].data[...] = VGG16net.params['conv4_3'][0].data[...]
+                net.params['conv4_3'][1].data[...] = VGG16net.params['conv4_3'][1].data[...]
+
+                net.params['conv5_1'][0].data[...] = VGG16net.params['conv5_1'][0].data[...]
+                net.params['conv5_1'][1].data[...] = VGG16net.params['conv5_1'][1].data[...]
+                net.params['conv5_2'][0].data[...] = VGG16net.params['conv5_2'][0].data[...]
+                net.params['conv5_2'][1].data[...] = VGG16net.params['conv5_2'][1].data[...]
+                net.params['conv5_3'][0].data[...] = VGG16net.params['conv5_3'][0].data[...]
+                net.params['conv5_3'][1].data[...] = VGG16net.params['conv5_3'][1].data[...]
+
+                ## Adding the below layer now
+                net.params['conv1_1_p'][0].data[...] = VGG16net.params['conv1_1'][0].data[...]
+                net.params['conv1_1_p'][1].data[...] = VGG16net.params['conv1_1'][1].data[...]
+                net.params['conv1_2_p'][0].data[...] = VGG16net.params['conv1_2'][0].data[...]
+                net.params['conv1_2_p'][1].data[...] = VGG16net.params['conv1_2'][1].data[...]
+
+                net.params['conv2_1_p'][0].data[...] = VGG16net.params['conv2_1'][0].data[...]
+                net.params['conv2_1_p'][1].data[...] = VGG16net.params['conv2_1'][1].data[...]
+                net.params['conv2_2_p'][0].data[...] = VGG16net.params['conv2_2'][0].data[...]
+                net.params['conv2_2_p'][1].data[...] = VGG16net.params['conv2_2'][1].data[...]
+
+                net.params['conv3_1_p'][0].data[...] = VGG16net.params['conv3_1'][0].data[...]
+                net.params['conv3_1_p'][1].data[...] = VGG16net.params['conv3_1'][1].data[...]
+                net.params['conv3_2_p'][0].data[...] = VGG16net.params['conv3_2'][0].data[...]
+                net.params['conv3_2_p'][1].data[...] = VGG16net.params['conv3_2'][1].data[...]
+                net.params['conv3_3_p'][0].data[...] = VGG16net.params['conv3_3'][0].data[...]
+                net.params['conv3_3_p'][1].data[...] = VGG16net.params['conv3_3'][1].data[...]
+
+                net.params['conv4_1_p'][0].data[...] = VGG16net.params['conv4_1'][0].data[...]
+                net.params['conv4_1_p'][1].data[...] = VGG16net.params['conv4_1'][1].data[...]
+                net.params['conv4_2_p'][0].data[...] = VGG16net.params['conv4_2'][0].data[...]
+                net.params['conv4_2_p'][1].data[...] = VGG16net.params['conv4_2'][1].data[...]
+                net.params['conv4_3_p'][0].data[...] = VGG16net.params['conv4_3'][0].data[...]
+                net.params['conv4_3_p'][1].data[...] = VGG16net.params['conv4_3'][1].data[...]
+
+                net.params['conv5_1_p'][0].data[...] = VGG16net.params['conv5_1'][0].data[...]
+                net.params['conv5_1_p'][1].data[...] = VGG16net.params['conv5_1'][1].data[...]
+                net.params['conv5_2_p'][0].data[...] = VGG16net.params['conv5_2'][0].data[...]
+                net.params['conv5_2_p'][1].data[...] = VGG16net.params['conv5_2'][1].data[...]
+                net.params['conv5_3_p'][0].data[...] = VGG16net.params['conv5_3'][0].data[...]
+                net.params['conv5_3_p'][1].data[...] = VGG16net.params['conv5_3'][1].data[...]
+                ##
             else:
                 logger.error('solver file required')
                 return

--- a/goturn/network/regressor.py
+++ b/goturn/network/regressor.py
@@ -121,7 +121,7 @@ class regressor:
                 #net.copy_from(caffe_model)
 
                 ## Assigning the weight from vgg16 pretrained layer to vgg16 feature extractor parallel layers
-                VGG16net = caffe.Net('vgg16 protofile', caffe_model, caffe.TEST)
+                VGG16net = caffe.Net('/home/virendra/dlcv/PY-GOTURN/PY-GOTURN/nets/VGG_ILSVRC_16_layers_deploy.prototxt', caffe_model, caffe.TEST)
                 #W = net.params['con_1'][0].data[...]
                 #b = net.params['con_1'][1].data[...]
                 #net = caffe.Net('path/to/conv2.prototxt', 'path/to/conv2.caffemodel', caffe.TEST)

--- a/nets/VGG_ILSVRC_16_layers_deploy.prototxt
+++ b/nets/VGG_ILSVRC_16_layers_deploy.prototxt
@@ -1,0 +1,345 @@
+name: "VGG_ILSVRC_16_layers"
+input: "data"
+input_dim: 10
+input_dim: 3
+input_dim: 224
+input_dim: 224
+layers {
+  bottom: "data"
+  top: "conv1_1"
+  name: "conv1_1"
+  type: CONVOLUTION
+  convolution_param {
+    num_output: 64
+    pad: 1
+    kernel_size: 3
+  }
+}
+layers {
+  bottom: "conv1_1"
+  top: "conv1_1"
+  name: "relu1_1"
+  type: RELU
+}
+layers {
+  bottom: "conv1_1"
+  top: "conv1_2"
+  name: "conv1_2"
+  type: CONVOLUTION
+  convolution_param {
+    num_output: 64
+    pad: 1
+    kernel_size: 3
+  }
+}
+layers {
+  bottom: "conv1_2"
+  top: "conv1_2"
+  name: "relu1_2"
+  type: RELU
+}
+layers {
+  bottom: "conv1_2"
+  top: "pool1"
+  name: "pool1"
+  type: POOLING
+  pooling_param {
+    pool: MAX
+    kernel_size: 2
+    stride: 2
+  }
+}
+layers {
+  bottom: "pool1"
+  top: "conv2_1"
+  name: "conv2_1"
+  type: CONVOLUTION
+  convolution_param {
+    num_output: 128
+    pad: 1
+    kernel_size: 3
+  }
+}
+layers {
+  bottom: "conv2_1"
+  top: "conv2_1"
+  name: "relu2_1"
+  type: RELU
+}
+layers {
+  bottom: "conv2_1"
+  top: "conv2_2"
+  name: "conv2_2"
+  type: CONVOLUTION
+  convolution_param {
+    num_output: 128
+    pad: 1
+    kernel_size: 3
+  }
+}
+layers {
+  bottom: "conv2_2"
+  top: "conv2_2"
+  name: "relu2_2"
+  type: RELU
+}
+layers {
+  bottom: "conv2_2"
+  top: "pool2"
+  name: "pool2"
+  type: POOLING
+  pooling_param {
+    pool: MAX
+    kernel_size: 2
+    stride: 2
+  }
+}
+layers {
+  bottom: "pool2"
+  top: "conv3_1"
+  name: "conv3_1"
+  type: CONVOLUTION
+  convolution_param {
+    num_output: 256
+    pad: 1
+    kernel_size: 3
+  }
+}
+layers {
+  bottom: "conv3_1"
+  top: "conv3_1"
+  name: "relu3_1"
+  type: RELU
+}
+layers {
+  bottom: "conv3_1"
+  top: "conv3_2"
+  name: "conv3_2"
+  type: CONVOLUTION
+  convolution_param {
+    num_output: 256
+    pad: 1
+    kernel_size: 3
+  }
+}
+layers {
+  bottom: "conv3_2"
+  top: "conv3_2"
+  name: "relu3_2"
+  type: RELU
+}
+layers {
+  bottom: "conv3_2"
+  top: "conv3_3"
+  name: "conv3_3"
+  type: CONVOLUTION
+  convolution_param {
+    num_output: 256
+    pad: 1
+    kernel_size: 3
+  }
+}
+layers {
+  bottom: "conv3_3"
+  top: "conv3_3"
+  name: "relu3_3"
+  type: RELU
+}
+layers {
+  bottom: "conv3_3"
+  top: "pool3"
+  name: "pool3"
+  type: POOLING
+  pooling_param {
+    pool: MAX
+    kernel_size: 2
+    stride: 2
+  }
+}
+layers {
+  bottom: "pool3"
+  top: "conv4_1"
+  name: "conv4_1"
+  type: CONVOLUTION
+  convolution_param {
+    num_output: 512
+    pad: 1
+    kernel_size: 3
+  }
+}
+layers {
+  bottom: "conv4_1"
+  top: "conv4_1"
+  name: "relu4_1"
+  type: RELU
+}
+layers {
+  bottom: "conv4_1"
+  top: "conv4_2"
+  name: "conv4_2"
+  type: CONVOLUTION
+  convolution_param {
+    num_output: 512
+    pad: 1
+    kernel_size: 3
+  }
+}
+layers {
+  bottom: "conv4_2"
+  top: "conv4_2"
+  name: "relu4_2"
+  type: RELU
+}
+layers {
+  bottom: "conv4_2"
+  top: "conv4_3"
+  name: "conv4_3"
+  type: CONVOLUTION
+  convolution_param {
+    num_output: 512
+    pad: 1
+    kernel_size: 3
+  }
+}
+layers {
+  bottom: "conv4_3"
+  top: "conv4_3"
+  name: "relu4_3"
+  type: RELU
+}
+layers {
+  bottom: "conv4_3"
+  top: "pool4"
+  name: "pool4"
+  type: POOLING
+  pooling_param {
+    pool: MAX
+    kernel_size: 2
+    stride: 2
+  }
+}
+layers {
+  bottom: "pool4"
+  top: "conv5_1"
+  name: "conv5_1"
+  type: CONVOLUTION
+  convolution_param {
+    num_output: 512
+    pad: 1
+    kernel_size: 3
+  }
+}
+layers {
+  bottom: "conv5_1"
+  top: "conv5_1"
+  name: "relu5_1"
+  type: RELU
+}
+layers {
+  bottom: "conv5_1"
+  top: "conv5_2"
+  name: "conv5_2"
+  type: CONVOLUTION
+  convolution_param {
+    num_output: 512
+    pad: 1
+    kernel_size: 3
+  }
+}
+layers {
+  bottom: "conv5_2"
+  top: "conv5_2"
+  name: "relu5_2"
+  type: RELU
+}
+layers {
+  bottom: "conv5_2"
+  top: "conv5_3"
+  name: "conv5_3"
+  type: CONVOLUTION
+  convolution_param {
+    num_output: 512
+    pad: 1
+    kernel_size: 3
+  }
+}
+layers {
+  bottom: "conv5_3"
+  top: "conv5_3"
+  name: "relu5_3"
+  type: RELU
+}
+layers {
+  bottom: "conv5_3"
+  top: "pool5"
+  name: "pool5"
+  type: POOLING
+  pooling_param {
+    pool: MAX
+    kernel_size: 2
+    stride: 2
+  }
+}
+layers {
+  bottom: "pool5"
+  top: "fc6"
+  name: "fc6"
+  type: INNER_PRODUCT
+  inner_product_param {
+    num_output: 4096
+  }
+}
+layers {
+  bottom: "fc6"
+  top: "fc6"
+  name: "relu6"
+  type: RELU
+}
+layers {
+  bottom: "fc6"
+  top: "fc6"
+  name: "drop6"
+  type: DROPOUT
+  dropout_param {
+    dropout_ratio: 0.5
+  }
+}
+layers {
+  bottom: "fc6"
+  top: "fc7"
+  name: "fc7"
+  type: INNER_PRODUCT
+  inner_product_param {
+    num_output: 4096
+  }
+}
+layers {
+  bottom: "fc7"
+  top: "fc7"
+  name: "relu7"
+  type: RELU
+}
+layers {
+  bottom: "fc7"
+  top: "fc7"
+  name: "drop7"
+  type: DROPOUT
+  dropout_param {
+    dropout_ratio: 0.5
+  }
+}
+layers {
+  bottom: "fc7"
+  top: "fc8"
+  name: "fc8"
+  type: INNER_PRODUCT
+  inner_product_param {
+    num_output: 1000
+  }
+}
+layers {
+  bottom: "fc8"
+  top: "prob"
+  name: "prob"
+  type: SOFTMAX
+}

--- a/nets/backup-VGG_ILSVRC_16_layers_deploy.prototxt
+++ b/nets/backup-VGG_ILSVRC_16_layers_deploy.prototxt
@@ -1,0 +1,345 @@
+name: "VGG_ILSVRC_16_layers"
+input: "data"
+input_dim: 10
+input_dim: 3
+input_dim: 224
+input_dim: 224
+layers {
+  bottom: "data"
+  top: "conv1_1"
+  name: "conv1_1"
+  type: CONVOLUTION
+  convolution_param {
+    num_output: 64
+    pad: 1
+    kernel_size: 3
+  }
+}
+layers {
+  bottom: "conv1_1"
+  top: "conv1_1"
+  name: "relu1_1"
+  type: RELU
+}
+layers {
+  bottom: "conv1_1"
+  top: "conv1_2"
+  name: "conv1_2"
+  type: CONVOLUTION
+  convolution_param {
+    num_output: 64
+    pad: 1
+    kernel_size: 3
+  }
+}
+layers {
+  bottom: "conv1_2"
+  top: "conv1_2"
+  name: "relu1_2"
+  type: RELU
+}
+layers {
+  bottom: "conv1_2"
+  top: "pool1"
+  name: "pool1"
+  type: POOLING
+  pooling_param {
+    pool: MAX
+    kernel_size: 2
+    stride: 2
+  }
+}
+layers {
+  bottom: "pool1"
+  top: "conv2_1"
+  name: "conv2_1"
+  type: CONVOLUTION
+  convolution_param {
+    num_output: 128
+    pad: 1
+    kernel_size: 3
+  }
+}
+layers {
+  bottom: "conv2_1"
+  top: "conv2_1"
+  name: "relu2_1"
+  type: RELU
+}
+layers {
+  bottom: "conv2_1"
+  top: "conv2_2"
+  name: "conv2_2"
+  type: CONVOLUTION
+  convolution_param {
+    num_output: 128
+    pad: 1
+    kernel_size: 3
+  }
+}
+layers {
+  bottom: "conv2_2"
+  top: "conv2_2"
+  name: "relu2_2"
+  type: RELU
+}
+layers {
+  bottom: "conv2_2"
+  top: "pool2"
+  name: "pool2"
+  type: POOLING
+  pooling_param {
+    pool: MAX
+    kernel_size: 2
+    stride: 2
+  }
+}
+layers {
+  bottom: "pool2"
+  top: "conv3_1"
+  name: "conv3_1"
+  type: CONVOLUTION
+  convolution_param {
+    num_output: 256
+    pad: 1
+    kernel_size: 3
+  }
+}
+layers {
+  bottom: "conv3_1"
+  top: "conv3_1"
+  name: "relu3_1"
+  type: RELU
+}
+layers {
+  bottom: "conv3_1"
+  top: "conv3_2"
+  name: "conv3_2"
+  type: CONVOLUTION
+  convolution_param {
+    num_output: 256
+    pad: 1
+    kernel_size: 3
+  }
+}
+layers {
+  bottom: "conv3_2"
+  top: "conv3_2"
+  name: "relu3_2"
+  type: RELU
+}
+layers {
+  bottom: "conv3_2"
+  top: "conv3_3"
+  name: "conv3_3"
+  type: CONVOLUTION
+  convolution_param {
+    num_output: 256
+    pad: 1
+    kernel_size: 3
+  }
+}
+layers {
+  bottom: "conv3_3"
+  top: "conv3_3"
+  name: "relu3_3"
+  type: RELU
+}
+layers {
+  bottom: "conv3_3"
+  top: "pool3"
+  name: "pool3"
+  type: POOLING
+  pooling_param {
+    pool: MAX
+    kernel_size: 2
+    stride: 2
+  }
+}
+layers {
+  bottom: "pool3"
+  top: "conv4_1"
+  name: "conv4_1"
+  type: CONVOLUTION
+  convolution_param {
+    num_output: 512
+    pad: 1
+    kernel_size: 3
+  }
+}
+layers {
+  bottom: "conv4_1"
+  top: "conv4_1"
+  name: "relu4_1"
+  type: RELU
+}
+layers {
+  bottom: "conv4_1"
+  top: "conv4_2"
+  name: "conv4_2"
+  type: CONVOLUTION
+  convolution_param {
+    num_output: 512
+    pad: 1
+    kernel_size: 3
+  }
+}
+layers {
+  bottom: "conv4_2"
+  top: "conv4_2"
+  name: "relu4_2"
+  type: RELU
+}
+layers {
+  bottom: "conv4_2"
+  top: "conv4_3"
+  name: "conv4_3"
+  type: CONVOLUTION
+  convolution_param {
+    num_output: 512
+    pad: 1
+    kernel_size: 3
+  }
+}
+layers {
+  bottom: "conv4_3"
+  top: "conv4_3"
+  name: "relu4_3"
+  type: RELU
+}
+layers {
+  bottom: "conv4_3"
+  top: "pool4"
+  name: "pool4"
+  type: POOLING
+  pooling_param {
+    pool: MAX
+    kernel_size: 2
+    stride: 2
+  }
+}
+layers {
+  bottom: "pool4"
+  top: "conv5_1"
+  name: "conv5_1"
+  type: CONVOLUTION
+  convolution_param {
+    num_output: 512
+    pad: 1
+    kernel_size: 3
+  }
+}
+layers {
+  bottom: "conv5_1"
+  top: "conv5_1"
+  name: "relu5_1"
+  type: RELU
+}
+layers {
+  bottom: "conv5_1"
+  top: "conv5_2"
+  name: "conv5_2"
+  type: CONVOLUTION
+  convolution_param {
+    num_output: 512
+    pad: 1
+    kernel_size: 3
+  }
+}
+layers {
+  bottom: "conv5_2"
+  top: "conv5_2"
+  name: "relu5_2"
+  type: RELU
+}
+layers {
+  bottom: "conv5_2"
+  top: "conv5_3"
+  name: "conv5_3"
+  type: CONVOLUTION
+  convolution_param {
+    num_output: 512
+    pad: 1
+    kernel_size: 3
+  }
+}
+layers {
+  bottom: "conv5_3"
+  top: "conv5_3"
+  name: "relu5_3"
+  type: RELU
+}
+layers {
+  bottom: "conv5_3"
+  top: "pool5"
+  name: "pool5"
+  type: POOLING
+  pooling_param {
+    pool: MAX
+    kernel_size: 2
+    stride: 2
+  }
+}
+layers {
+  bottom: "pool5"
+  top: "fc6"
+  name: "fc6"
+  type: INNER_PRODUCT
+  inner_product_param {
+    num_output: 4096
+  }
+}
+layers {
+  bottom: "fc6"
+  top: "fc6"
+  name: "relu6"
+  type: RELU
+}
+layers {
+  bottom: "fc6"
+  top: "fc6"
+  name: "drop6"
+  type: DROPOUT
+  dropout_param {
+    dropout_ratio: 0.5
+  }
+}
+layers {
+  bottom: "fc6"
+  top: "fc7"
+  name: "fc7"
+  type: INNER_PRODUCT
+  inner_product_param {
+    num_output: 4096
+  }
+}
+layers {
+  bottom: "fc7"
+  top: "fc7"
+  name: "relu7"
+  type: RELU
+}
+layers {
+  bottom: "fc7"
+  top: "fc7"
+  name: "drop7"
+  type: DROPOUT
+  dropout_param {
+    dropout_ratio: 0.5
+  }
+}
+layers {
+  bottom: "fc7"
+  top: "fc8"
+  name: "fc8"
+  type: INNER_PRODUCT
+  inner_product_param {
+    num_output: 1000
+  }
+}
+layers {
+  bottom: "fc8"
+  top: "prob"
+  name: "prob"
+  type: SOFTMAX
+}

--- a/nets/solver.prototxt
+++ b/nets/solver.prototxt
@@ -1,4 +1,4 @@
-net:'/home/nrupatunga/NThere/DL-Workspace/CAFFE/PY-GOTURN/nets/tracker.prototxt'
+net:'/home/virendra/dlcv/PY-GOTURN/PY-GOTURN/nets/tracker-vgg16.prototxt'
 base_lr: 0.000001
 lr_policy: "step"
 gamma: 0.1

--- a/nets/tracker-vgg16.prototxt
+++ b/nets/tracker-vgg16.prototxt
@@ -1,0 +1,854 @@
+name: "VGG_ILSVRC_16_layers"
+
+input: "target"
+input: "image"
+input: "bbox"
+
+#target
+input_dim: 10
+input_dim: 3
+input_dim: 224
+input_dim: 224
+
+#image
+input_dim: 10
+input_dim: 3
+input_dim: 224
+input_dim: 224
+
+#bbox
+input_dim: 1
+input_dim: 4
+input_dim: 1
+input_dim: 1
+
+layers {
+  bottom: "target"
+  top: "conv1_1"
+  name: "conv1_1"
+  type: CONVOLUTION
+  convolution_param {
+    num_output: 64
+    pad: 1
+    kernel_size: 3
+  }
+}
+
+layers {
+  bottom: "conv1_1"
+  top: "conv1_1"
+  name: "relu1_1"
+  type: RELU
+}
+
+layers {
+  bottom: "conv1_1"
+  top: "conv1_2"
+  name: "conv1_2"
+  type: CONVOLUTION
+  convolution_param {
+    num_output: 64
+    pad: 1
+    kernel_size: 3
+  }
+}
+
+layers {
+  bottom: "conv1_2"
+  top: "conv1_2"
+  name: "relu1_2"
+  type: RELU
+}
+
+layers {
+  bottom: "conv1_2"
+  top: "pool1"
+  name: "pool1"
+  type: POOLING
+  pooling_param {
+    pool: MAX
+    kernel_size: 2
+    stride: 2
+  }
+}
+
+layers {
+  bottom: "pool1"
+  top: "conv2_1"
+  name: "conv2_1"
+  type: CONVOLUTION
+  convolution_param {
+    num_output: 128
+    pad: 1
+    kernel_size: 3
+  }
+}
+
+layers {
+  bottom: "conv2_1"
+  top: "conv2_1"
+  name: "relu2_1"
+  type: RELU
+}
+
+layers {
+  bottom: "conv2_1"
+  top: "conv2_2"
+  name: "conv2_2"
+  type: CONVOLUTION
+  convolution_param {
+    num_output: 128
+    pad: 1
+    kernel_size: 3
+  }
+}
+
+layers {
+  bottom: "conv2_2"
+  top: "conv2_2"
+  name: "relu2_2"
+  type: RELU
+}
+
+layers {
+  bottom: "conv2_2"
+  top: "pool2"
+  name: "pool2"
+  type: POOLING
+  pooling_param {
+    pool: MAX
+    kernel_size: 2
+    stride: 2
+  }
+}
+
+layers {
+  bottom: "pool2"
+  top: "conv3_1"
+  name: "conv3_1"
+  type: CONVOLUTION
+  convolution_param {
+    num_output: 256
+    pad: 1
+    kernel_size: 3
+  }
+}
+
+layers {
+  bottom: "conv3_1"
+  top: "conv3_1"
+  name: "relu3_1"
+  type: RELU
+}
+
+layers {
+  bottom: "conv3_1"
+  top: "conv3_2"
+  name: "conv3_2"
+  type: CONVOLUTION
+  convolution_param {
+    num_output: 256
+    pad: 1
+    kernel_size: 3
+  }
+}
+
+layers {
+  bottom: "conv3_2"
+  top: "conv3_2"
+  name: "relu3_2"
+  type: RELU
+}
+
+layers {
+  bottom: "conv3_2"
+  top: "conv3_3"
+  name: "conv3_3"
+  type: CONVOLUTION
+  convolution_param {
+    num_output: 256
+    pad: 1
+    kernel_size: 3
+  }
+}
+
+layers {
+  bottom: "conv3_3"
+  top: "conv3_3"
+  name: "relu3_3"
+  type: RELU
+}
+
+layers {
+  bottom: "conv3_3"
+  top: "pool3"
+  name: "pool3"
+  type: POOLING
+  pooling_param {
+    pool: MAX
+    kernel_size: 2
+    stride: 2
+  }
+}
+
+layers {
+  bottom: "pool3"
+  top: "conv4_1"
+  name: "conv4_1"
+  type: CONVOLUTION
+  convolution_param {
+    num_output: 512
+    pad: 1
+    kernel_size: 3
+  }
+}
+
+layers {
+  bottom: "conv4_1"
+  top: "conv4_1"
+  name: "relu4_1"
+  type: RELU
+}
+
+layers {
+  bottom: "conv4_1"
+  top: "conv4_2"
+  name: "conv4_2"
+  type: CONVOLUTION
+  convolution_param {
+    num_output: 512
+    pad: 1
+    kernel_size: 3
+  }
+}
+
+layers {
+  bottom: "conv4_2"
+  top: "conv4_2"
+  name: "relu4_2"
+  type: RELU
+}
+
+layers {
+  bottom: "conv4_2"
+  top: "conv4_3"
+  name: "conv4_3"
+  type: CONVOLUTION
+  convolution_param {
+    num_output: 512
+    pad: 1
+    kernel_size: 3
+  }
+}
+
+layers {
+  bottom: "conv4_3"
+  top: "conv4_3"
+  name: "relu4_3"
+  type: RELU
+}
+
+layers {
+  bottom: "conv4_3"
+  top: "pool4"
+  name: "pool4"
+  type: POOLING
+  pooling_param {
+    pool: MAX
+    kernel_size: 2
+    stride: 2
+  }
+}
+
+layers {
+  bottom: "pool4"
+  top: "conv5_1"
+  name: "conv5_1"
+  type: CONVOLUTION
+  convolution_param {
+    num_output: 512
+    pad: 1
+    kernel_size: 3
+  }
+}
+
+layers {
+  bottom: "conv5_1"
+  top: "conv5_1"
+  name: "relu5_1"
+  type: RELU
+}
+
+layers {
+  bottom: "conv5_1"
+  top: "conv5_2"
+  name: "conv5_2"
+  type: CONVOLUTION
+  convolution_param {
+    num_output: 512
+    pad: 1
+    kernel_size: 3
+  }
+}
+
+layers {
+  bottom: "conv5_2"
+  top: "conv5_2"
+  name: "relu5_2"
+  type: RELU
+}
+
+layers {
+  bottom: "conv5_2"
+  top: "conv5_3"
+  name: "conv5_3"
+  type: CONVOLUTION
+  convolution_param {
+    num_output: 512
+    pad: 1
+    kernel_size: 3
+  }
+}
+
+layers {
+  bottom: "conv5_3"
+  top: "conv5_3"
+  name: "relu5_3"
+  type: RELU
+}
+
+layers {
+  bottom: "conv5_3"
+  top: "pool5"
+  name: "pool5"
+  type: POOLING
+  pooling_param {
+    pool: MAX
+    kernel_size: 2
+    stride: 2
+  }
+}
+
+layers {
+  bottom: "pool5"
+  top: "fc6"
+  name: "fc6"
+  type: INNER_PRODUCT
+  inner_product_param {
+    num_output: 4096
+  }
+}
+
+
+
+layers {
+  bottom: "image"
+  top: "conv1_1_p"
+  name: "conv1_1_p"
+  type: CONVOLUTION
+  convolution_param {
+    num_output: 64
+    pad: 1
+    kernel_size: 3
+  }
+}
+
+layers {
+  bottom: "conv1_1_p"
+  top: "conv1_1_p"
+  name: "relu1_1_p"
+  type: RELU
+}
+
+layers {
+  bottom: "conv1_1_p"
+  top: "conv1_2_p"
+  name: "conv1_2_p"
+  type: CONVOLUTION
+  convolution_param {
+    num_output: 64
+    pad: 1
+    kernel_size: 3
+  }
+}
+
+layers {
+  bottom: "conv1_2_p"
+  top: "conv1_2_p"
+  name: "relu1_2_p"
+  type: RELU
+}
+
+layers {
+  bottom: "conv1_2_p"
+  top: "pool1_p"
+  name: "pool1_p"
+  type: POOLING
+  pooling_param {
+    pool: MAX
+    kernel_size: 2
+    stride: 2
+  }
+}
+
+layers {
+  bottom: "pool1_p"
+  top: "conv2_1_p"
+  name: "conv2_1_p"
+  type: CONVOLUTION
+  convolution_param {
+    num_output: 128
+    pad: 1
+    kernel_size: 3
+  }
+}
+
+layers {
+  bottom: "conv2_1_p"
+  top: "conv2_1_p"
+  name: "relu2_1_p"
+  type: RELU
+}
+
+layers {
+  bottom: "conv2_1_p"
+  top: "conv2_2_p"
+  name: "conv2_2_p"
+  type: CONVOLUTION
+  convolution_param {
+    num_output: 128
+    pad: 1
+    kernel_size: 3
+  }
+}
+
+layers {
+  bottom: "conv2_2_p"
+  top: "conv2_2_p"
+  name: "relu2_2_p"
+  type: RELU
+}
+
+layers {
+  bottom: "conv2_2_p"
+  top: "pool2_p"
+  name: "pool2_p"
+  type: POOLING
+  pooling_param {
+    pool: MAX
+    kernel_size: 2
+    stride: 2
+  }
+}
+
+layers {
+  bottom: "pool2_p"
+  top: "conv3_1_p"
+  name: "conv3_1_p"
+  type: CONVOLUTION
+  convolution_param {
+    num_output: 256
+    pad: 1
+    kernel_size: 3
+  }
+}
+
+layers {
+  bottom: "conv3_1_p"
+  top: "conv3_1_p"
+  name: "relu3_1_p"
+  type: RELU
+}
+
+layers {
+  bottom: "conv3_1_p"
+  top: "conv3_2_p"
+  name: "conv3_2_p"
+  type: CONVOLUTION
+  convolution_param {
+    num_output: 256
+    pad: 1
+    kernel_size: 3
+  }
+}
+
+layers {
+  bottom: "conv3_2_p"
+  top: "conv3_2_p"
+  name: "relu3_2_p"
+  type: RELU
+}
+
+layers {
+  bottom: "conv3_2_p"
+  top: "conv3_3_p"
+  name: "conv3_3_p"
+  type: CONVOLUTION
+  convolution_param {
+    num_output: 256
+    pad: 1
+    kernel_size: 3
+  }
+}
+
+layers {
+  bottom: "conv3_3_p"
+  top: "conv3_3_p"
+  name: "relu3_3_p"
+  type: RELU
+}
+
+layers {
+  bottom: "conv3_3_p"
+  top: "pool3_p"
+  name: "pool3_p"
+  type: POOLING
+  pooling_param {
+    pool: MAX
+    kernel_size: 2
+    stride: 2
+  }
+}
+
+layers {
+  bottom: "pool3_p"
+  top: "conv4_1_p"
+  name: "conv4_1_p"
+  type: CONVOLUTION
+  convolution_param {
+    num_output: 512
+    pad: 1
+    kernel_size: 3
+  }
+}
+
+layers {
+  bottom: "conv4_1_p"
+  top: "conv4_1_p"
+  name: "relu4_1_p"
+  type: RELU
+}
+
+layers {
+  bottom: "conv4_1_p"
+  top: "conv4_2_p"
+  name: "conv4_2_p"
+  type: CONVOLUTION
+  convolution_param {
+    num_output: 512
+    pad: 1
+    kernel_size: 3
+  }
+}
+
+layers {
+  bottom: "conv4_2_p"
+  top: "conv4_2_p"
+  name: "relu4_2_p"
+  type: RELU
+}
+
+layers {
+  bottom: "conv4_2_p"
+  top: "conv4_3_p"
+  name: "conv4_3_p"
+  type: CONVOLUTION
+  convolution_param {
+    num_output: 512
+    pad: 1
+    kernel_size: 3
+  }
+}
+
+layers {
+  bottom: "conv4_3_p"
+  top: "conv4_3_p"
+  name: "relu4_3_p"
+  type: RELU
+}
+
+layers {
+  bottom: "conv4_3_p"
+  top: "pool4_p"
+  name: "pool4_p"
+  type: POOLING
+  pooling_param {
+    pool: MAX
+    kernel_size: 2
+    stride: 2
+  }
+}
+
+layers {
+  bottom: "pool4_p"
+  top: "conv5_1_p"
+  name: "conv5_1_p"
+  type: CONVOLUTION
+  convolution_param {
+    num_output: 512
+    pad: 1
+    kernel_size: 3
+  }
+}
+
+layers {
+  bottom: "conv5_1_p"
+  top: "conv5_1_p"
+  name: "relu5_1_p"
+  type: RELU
+}
+
+layers {
+  bottom: "conv5_1_p"
+  top: "conv5_2_p"
+  name: "conv5_2_p"
+  type: CONVOLUTION
+  convolution_param {
+    num_output: 512
+    pad: 1
+    kernel_size: 3
+  }
+}
+
+layers {
+  bottom: "conv5_2_p"
+  top: "conv5_2_p"
+  name: "relu5_2_p"
+  type: RELU
+}
+
+layers {
+  bottom: "conv5_2_p"
+  top: "conv5_3_p"
+  name: "conv5_3_p"
+  type: CONVOLUTION
+  convolution_param {
+    num_output: 512
+    pad: 1
+    kernel_size: 3
+  }
+}
+
+layers {
+  bottom: "conv5_3_p"
+  top: "conv5_3_p"
+  name: "relu5_3_p"
+  type: RELU
+}
+
+layers {
+  bottom: "conv5_3_p"
+  top: "pool5_p"
+  name: "pool5_p"
+  type: POOLING
+  pooling_param {
+    pool: MAX
+    kernel_size: 2
+    stride: 2
+  }
+}
+
+layer {
+  name: "concat"
+  type: "Concat"
+  bottom: "pool5"
+  bottom: "pool5_p"
+  top: "pool5_concat"
+  concat_param {
+    axis: 1
+  }
+}
+
+layer {
+  name: "fc6-new"
+  type: "InnerProduct"
+  bottom: "pool5_concat"
+  top: "fc6"
+  param {
+    lr_mult: 10
+    decay_mult: 1
+  }
+  param {
+    lr_mult: 20
+    decay_mult: 0
+  }
+  inner_product_param {
+    num_output: 4096
+    weight_filler {
+      type: "gaussian"
+      std: 0.005
+    }
+    bias_filler {
+      type: "constant"
+      value: 1
+    }
+  }
+}
+
+layer {
+  name: "relu6"
+  type: "ReLU"
+  bottom: "fc6"
+  top: "fc6"
+}
+
+layer {
+  name: "drop6"
+  type: "Dropout"
+  bottom: "fc6"
+  top: "fc6"
+  dropout_param {
+    dropout_ratio: 0.5
+  }
+}
+
+layer {
+  name: "fc7-new"
+  type: "InnerProduct"
+  bottom: "fc6"
+  top: "fc7"
+  param {
+    lr_mult: 10
+    decay_mult: 1
+  }
+  param {
+    lr_mult: 20
+    decay_mult: 0
+  }
+  inner_product_param {
+    num_output: 4096
+    weight_filler {
+      type: "gaussian"
+      std: 0.005
+    }
+    bias_filler {
+      type: "constant"
+      value: 1
+    }
+  }
+}
+
+layer {
+  name: "relu7"
+  type: "ReLU"
+  bottom: "fc7"
+  top: "fc7"
+}
+
+layer {
+  name: "drop7"
+  type: "Dropout"
+  bottom: "fc7"
+  top: "fc7"
+  dropout_param {
+    dropout_ratio: 0.5
+  }
+}
+
+layer {
+  name: "fc7-newb"
+  type: "InnerProduct"
+  bottom: "fc7"
+  top: "fc7b"
+  param {
+    lr_mult: 10
+    decay_mult: 1
+  }
+  param {
+    lr_mult: 20
+    decay_mult: 0
+  }
+  inner_product_param {
+    num_output: 4096
+    weight_filler {
+      type: "gaussian"
+      std: 0.005
+    }
+    bias_filler {
+      type: "constant"
+      value: 1
+    }
+  }
+}
+
+layer {
+  name: "relu7b"
+  type: "ReLU"
+  bottom: "fc7b"
+  top: "fc7b"
+}
+
+layer {
+  name: "drop7b"
+  type: "Dropout"
+  bottom: "fc7b"
+  top: "fc7b"
+  dropout_param {
+    dropout_ratio: 0.5
+  }
+}
+
+
+layer {
+  name: "fc8-shapes"
+  type: "InnerProduct"
+  bottom: "fc7b"
+  top: "fc8"
+  param {
+    lr_mult: 10
+    decay_mult: 1
+  }
+  param {
+    lr_mult: 20
+    decay_mult: 0
+  }
+  inner_product_param {
+    num_output: 4
+    weight_filler {
+      type: "gaussian"
+      std: 0.01
+    }
+    bias_filler {
+      type: "constant"
+      value: 0
+    }
+  }
+}
+
+layer {
+  name: "neg"
+  bottom: "bbox"
+  top: "bbox_neg"
+  type: "Power"
+  power_param {
+    power: 1
+    scale: -1
+    shift: 0
+  }
+}
+
+layer {
+  name: "flatten"
+  type: "Flatten"
+  bottom: "bbox_neg"
+  top: "bbox_neg_flat"
+}
+
+layer {
+  name: "subtract"
+  type: "Eltwise"
+  bottom: "fc8"
+  bottom: "bbox_neg_flat"
+  top: "out_diff"
+}
+
+layer {
+  name: "abssum"
+  type: "Reduction"
+  bottom: "out_diff"
+  top: "loss"
+  loss_weight: 1
+  reduction_param {
+    operation: 2
+  }
+}

--- a/nets/tracker-vgg16.prototxt
+++ b/nets/tracker-vgg16.prototxt
@@ -22,613 +22,552 @@ input_dim: 4
 input_dim: 1
 input_dim: 1
 
-layers {
+layer {
+  name: "conv1_1"
+  type: "Convolution"
   bottom: "target"
   top: "conv1_1"
-  name: "conv1_1"
-  type: CONVOLUTION
   convolution_param {
     num_output: 64
     pad: 1
     kernel_size: 3
   }
 }
-
-layers {
+layer {
+  name: "relu1_1"
+  type: "ReLU"
   bottom: "conv1_1"
   top: "conv1_1"
-  name: "relu1_1"
-  type: RELU
 }
-
-layers {
+layer {
+  name: "conv1_2"
+  type: "Convolution"
   bottom: "conv1_1"
   top: "conv1_2"
-  name: "conv1_2"
-  type: CONVOLUTION
   convolution_param {
     num_output: 64
     pad: 1
     kernel_size: 3
   }
 }
-
-layers {
+layer {
+  name: "relu1_2"
+  type: "ReLU"
   bottom: "conv1_2"
   top: "conv1_2"
-  name: "relu1_2"
-  type: RELU
 }
-
-layers {
+layer {
+  name: "pool1"
+  type: "Pooling"
   bottom: "conv1_2"
   top: "pool1"
-  name: "pool1"
-  type: POOLING
   pooling_param {
     pool: MAX
     kernel_size: 2
     stride: 2
   }
 }
-
-layers {
+layer {
+  name: "conv2_1"
+  type: "Convolution"
   bottom: "pool1"
   top: "conv2_1"
-  name: "conv2_1"
-  type: CONVOLUTION
   convolution_param {
     num_output: 128
     pad: 1
     kernel_size: 3
   }
 }
-
-layers {
+layer {
+  name: "relu2_1"
+  type: "ReLU"
   bottom: "conv2_1"
   top: "conv2_1"
-  name: "relu2_1"
-  type: RELU
 }
-
-layers {
+layer {
+  name: "conv2_2"
+  type: "Convolution"
   bottom: "conv2_1"
   top: "conv2_2"
-  name: "conv2_2"
-  type: CONVOLUTION
   convolution_param {
     num_output: 128
     pad: 1
     kernel_size: 3
   }
 }
-
-layers {
+layer {
+  name: "relu2_2"
+  type: "ReLU"
   bottom: "conv2_2"
   top: "conv2_2"
-  name: "relu2_2"
-  type: RELU
 }
-
-layers {
+layer {
+  name: "pool2"
+  type: "Pooling"
   bottom: "conv2_2"
   top: "pool2"
-  name: "pool2"
-  type: POOLING
   pooling_param {
     pool: MAX
     kernel_size: 2
     stride: 2
   }
 }
-
-layers {
+layer {
+  name: "conv3_1"
+  type: "Convolution"
   bottom: "pool2"
   top: "conv3_1"
-  name: "conv3_1"
-  type: CONVOLUTION
   convolution_param {
     num_output: 256
     pad: 1
     kernel_size: 3
   }
 }
-
-layers {
+layer {
+  name: "relu3_1"
+  type: "ReLU"
   bottom: "conv3_1"
   top: "conv3_1"
-  name: "relu3_1"
-  type: RELU
 }
-
-layers {
+layer {
+  name: "conv3_2"
+  type: "Convolution"
   bottom: "conv3_1"
   top: "conv3_2"
-  name: "conv3_2"
-  type: CONVOLUTION
   convolution_param {
     num_output: 256
     pad: 1
     kernel_size: 3
   }
 }
-
-layers {
+layer {
+  name: "relu3_2"
+  type: "ReLU"
   bottom: "conv3_2"
   top: "conv3_2"
-  name: "relu3_2"
-  type: RELU
 }
-
-layers {
+layer {
+  name: "conv3_3"
+  type: "Convolution"
   bottom: "conv3_2"
   top: "conv3_3"
-  name: "conv3_3"
-  type: CONVOLUTION
   convolution_param {
     num_output: 256
     pad: 1
     kernel_size: 3
   }
 }
-
-layers {
+layer {
+  name: "relu3_3"
+  type: "ReLU"
   bottom: "conv3_3"
   top: "conv3_3"
-  name: "relu3_3"
-  type: RELU
 }
-
-layers {
+layer {
+  name: "pool3"
+  type: "Pooling"
   bottom: "conv3_3"
   top: "pool3"
-  name: "pool3"
-  type: POOLING
   pooling_param {
     pool: MAX
     kernel_size: 2
     stride: 2
   }
 }
-
-layers {
+layer {
+  name: "conv4_1"
+  type: "Convolution"
   bottom: "pool3"
   top: "conv4_1"
-  name: "conv4_1"
-  type: CONVOLUTION
   convolution_param {
     num_output: 512
     pad: 1
     kernel_size: 3
   }
 }
-
-layers {
+layer {
+  name: "relu4_1"
+  type: "ReLU"
   bottom: "conv4_1"
   top: "conv4_1"
-  name: "relu4_1"
-  type: RELU
 }
-
-layers {
+layer {
+  name: "conv4_2"
+  type: "Convolution"
   bottom: "conv4_1"
   top: "conv4_2"
-  name: "conv4_2"
-  type: CONVOLUTION
   convolution_param {
     num_output: 512
     pad: 1
     kernel_size: 3
   }
 }
-
-layers {
+layer {
+  name: "relu4_2"
+  type: "ReLU"
   bottom: "conv4_2"
   top: "conv4_2"
-  name: "relu4_2"
-  type: RELU
 }
-
-layers {
+layer {
+  name: "conv4_3"
+  type: "Convolution"
   bottom: "conv4_2"
   top: "conv4_3"
-  name: "conv4_3"
-  type: CONVOLUTION
   convolution_param {
     num_output: 512
     pad: 1
     kernel_size: 3
   }
 }
-
-layers {
+layer {
+  name: "relu4_3"
+  type: "ReLU"
   bottom: "conv4_3"
   top: "conv4_3"
-  name: "relu4_3"
-  type: RELU
 }
-
-layers {
+layer {
+  name: "pool4"
+  type: "Pooling"
   bottom: "conv4_3"
   top: "pool4"
-  name: "pool4"
-  type: POOLING
   pooling_param {
     pool: MAX
     kernel_size: 2
     stride: 2
   }
 }
-
-layers {
+layer {
+  name: "conv5_1"
+  type: "Convolution"
   bottom: "pool4"
   top: "conv5_1"
-  name: "conv5_1"
-  type: CONVOLUTION
   convolution_param {
     num_output: 512
     pad: 1
     kernel_size: 3
   }
 }
-
-layers {
+layer {
+  name: "relu5_1"
+  type: "ReLU"
   bottom: "conv5_1"
   top: "conv5_1"
-  name: "relu5_1"
-  type: RELU
 }
-
-layers {
+layer {
+  name: "conv5_2"
+  type: "Convolution"
   bottom: "conv5_1"
   top: "conv5_2"
-  name: "conv5_2"
-  type: CONVOLUTION
   convolution_param {
     num_output: 512
     pad: 1
     kernel_size: 3
   }
 }
-
-layers {
+layer {
+  name: "relu5_2"
+  type: "ReLU"
   bottom: "conv5_2"
   top: "conv5_2"
-  name: "relu5_2"
-  type: RELU
 }
-
-layers {
+layer {
+  name: "conv5_3"
+  type: "Convolution"
   bottom: "conv5_2"
   top: "conv5_3"
-  name: "conv5_3"
-  type: CONVOLUTION
   convolution_param {
     num_output: 512
     pad: 1
     kernel_size: 3
   }
 }
-
-layers {
+layer {
+  name: "relu5_3"
+  type: "ReLU"
   bottom: "conv5_3"
   top: "conv5_3"
-  name: "relu5_3"
-  type: RELU
 }
-
-layers {
+layer {
+  name: "pool5"
+  type: "Pooling"
   bottom: "conv5_3"
   top: "pool5"
-  name: "pool5"
-  type: POOLING
   pooling_param {
     pool: MAX
     kernel_size: 2
     stride: 2
   }
 }
-
-layers {
+layer {
+  name: "conv1_1_p"
+  type: "Convolution"
   bottom: "image"
   top: "conv1_1_p"
-  name: "conv1_1_p"
-  type: CONVOLUTION
   convolution_param {
     num_output: 64
     pad: 1
     kernel_size: 3
   }
 }
-
-layers {
+layer {
+  name: "relu1_1_p"
+  type: "ReLU"
   bottom: "conv1_1_p"
   top: "conv1_1_p"
-  name: "relu1_1_p"
-  type: RELU
 }
-
-layers {
+layer {
+  name: "conv1_2_p"
+  type: "Convolution"
   bottom: "conv1_1_p"
   top: "conv1_2_p"
-  name: "conv1_2_p"
-  type: CONVOLUTION
   convolution_param {
     num_output: 64
     pad: 1
     kernel_size: 3
   }
 }
-
-layers {
+layer {
+  name: "relu1_2_p"
+  type: "ReLU"
   bottom: "conv1_2_p"
   top: "conv1_2_p"
-  name: "relu1_2_p"
-  type: RELU
 }
-
-layers {
+layer {
+  name: "pool1_p"
+  type: "Pooling"
   bottom: "conv1_2_p"
   top: "pool1_p"
-  name: "pool1_p"
-  type: POOLING
   pooling_param {
     pool: MAX
     kernel_size: 2
     stride: 2
   }
 }
-
-layers {
+layer {
+  name: "conv2_1_p"
+  type: "Convolution"
   bottom: "pool1_p"
   top: "conv2_1_p"
-  name: "conv2_1_p"
-  type: CONVOLUTION
   convolution_param {
     num_output: 128
     pad: 1
     kernel_size: 3
   }
 }
-
-layers {
+layer {
+  name: "relu2_1_p"
+  type: "ReLU"
   bottom: "conv2_1_p"
   top: "conv2_1_p"
-  name: "relu2_1_p"
-  type: RELU
 }
-
-layers {
+layer {
+  name: "conv2_2_p"
+  type: "Convolution"
   bottom: "conv2_1_p"
   top: "conv2_2_p"
-  name: "conv2_2_p"
-  type: CONVOLUTION
   convolution_param {
     num_output: 128
     pad: 1
     kernel_size: 3
   }
 }
-
-layers {
+layer {
+  name: "relu2_2_p"
+  type: "ReLU"
   bottom: "conv2_2_p"
   top: "conv2_2_p"
-  name: "relu2_2_p"
-  type: RELU
 }
-
-layers {
+layer {
+  name: "pool2_p"
+  type: "Pooling"
   bottom: "conv2_2_p"
   top: "pool2_p"
-  name: "pool2_p"
-  type: POOLING
   pooling_param {
     pool: MAX
     kernel_size: 2
     stride: 2
   }
 }
-
-layers {
+layer {
+  name: "conv3_1_p"
+  type: "Convolution"
   bottom: "pool2_p"
   top: "conv3_1_p"
-  name: "conv3_1_p"
-  type: CONVOLUTION
   convolution_param {
     num_output: 256
     pad: 1
     kernel_size: 3
   }
 }
-
-layers {
+layer {
+  name: "relu3_1_p"
+  type: "ReLU"
   bottom: "conv3_1_p"
   top: "conv3_1_p"
-  name: "relu3_1_p"
-  type: RELU
 }
-
-layers {
+layer {
+  name: "conv3_2_p"
+  type: "Convolution"
   bottom: "conv3_1_p"
   top: "conv3_2_p"
-  name: "conv3_2_p"
-  type: CONVOLUTION
   convolution_param {
     num_output: 256
     pad: 1
     kernel_size: 3
   }
 }
-
-layers {
+layer {
+  name: "relu3_2_p"
+  type: "ReLU"
   bottom: "conv3_2_p"
   top: "conv3_2_p"
-  name: "relu3_2_p"
-  type: RELU
 }
-
-layers {
+layer {
+  name: "conv3_3_p"
+  type: "Convolution"
   bottom: "conv3_2_p"
   top: "conv3_3_p"
-  name: "conv3_3_p"
-  type: CONVOLUTION
   convolution_param {
     num_output: 256
     pad: 1
     kernel_size: 3
   }
 }
-
-layers {
+layer {
+  name: "relu3_3_p"
+  type: "ReLU"
   bottom: "conv3_3_p"
   top: "conv3_3_p"
-  name: "relu3_3_p"
-  type: RELU
 }
-
-layers {
+layer {
+  name: "pool3_p"
+  type: "Pooling"
   bottom: "conv3_3_p"
   top: "pool3_p"
-  name: "pool3_p"
-  type: POOLING
   pooling_param {
     pool: MAX
     kernel_size: 2
     stride: 2
   }
 }
-
-layers {
+layer {
+  name: "conv4_1_p"
+  type: "Convolution"
   bottom: "pool3_p"
   top: "conv4_1_p"
-  name: "conv4_1_p"
-  type: CONVOLUTION
   convolution_param {
     num_output: 512
     pad: 1
     kernel_size: 3
   }
 }
-
-layers {
+layer {
+  name: "relu4_1_p"
+  type: "ReLU"
   bottom: "conv4_1_p"
   top: "conv4_1_p"
-  name: "relu4_1_p"
-  type: RELU
 }
-
-layers {
+layer {
+  name: "conv4_2_p"
+  type: "Convolution"
   bottom: "conv4_1_p"
   top: "conv4_2_p"
-  name: "conv4_2_p"
-  type: CONVOLUTION
   convolution_param {
     num_output: 512
     pad: 1
     kernel_size: 3
   }
 }
-
-layers {
+layer {
+  name: "relu4_2_p"
+  type: "ReLU"
   bottom: "conv4_2_p"
   top: "conv4_2_p"
-  name: "relu4_2_p"
-  type: RELU
 }
-
-layers {
+layer {
+  name: "conv4_3_p"
+  type: "Convolution"
   bottom: "conv4_2_p"
   top: "conv4_3_p"
-  name: "conv4_3_p"
-  type: CONVOLUTION
   convolution_param {
     num_output: 512
     pad: 1
     kernel_size: 3
   }
 }
-
-layers {
+layer {
+  name: "relu4_3_p"
+  type: "ReLU"
   bottom: "conv4_3_p"
   top: "conv4_3_p"
-  name: "relu4_3_p"
-  type: RELU
 }
-
-layers {
+layer {
+  name: "pool4_p"
+  type: "Pooling"
   bottom: "conv4_3_p"
   top: "pool4_p"
-  name: "pool4_p"
-  type: POOLING
   pooling_param {
     pool: MAX
     kernel_size: 2
     stride: 2
   }
 }
-
-layers {
+layer {
+  name: "conv5_1_p"
+  type: "Convolution"
   bottom: "pool4_p"
   top: "conv5_1_p"
-  name: "conv5_1_p"
-  type: CONVOLUTION
   convolution_param {
     num_output: 512
     pad: 1
     kernel_size: 3
   }
 }
-
-layers {
+layer {
+  name: "relu5_1_p"
+  type: "ReLU"
   bottom: "conv5_1_p"
   top: "conv5_1_p"
-  name: "relu5_1_p"
-  type: RELU
 }
-
-layers {
+layer {
+  name: "conv5_2_p"
+  type: "Convolution"
   bottom: "conv5_1_p"
   top: "conv5_2_p"
-  name: "conv5_2_p"
-  type: CONVOLUTION
   convolution_param {
     num_output: 512
     pad: 1
     kernel_size: 3
   }
 }
-
-layers {
+layer {
+  name: "relu5_2_p"
+  type: "ReLU"
   bottom: "conv5_2_p"
   top: "conv5_2_p"
-  name: "relu5_2_p"
-  type: RELU
 }
-
-layers {
+layer {
+  name: "conv5_3_p"
+  type: "Convolution"
   bottom: "conv5_2_p"
   top: "conv5_3_p"
-  name: "conv5_3_p"
-  type: CONVOLUTION
   convolution_param {
     num_output: 512
     pad: 1
     kernel_size: 3
   }
 }
-
-layers {
+layer {
+  name: "relu5_3_p"
+  type: "ReLU"
   bottom: "conv5_3_p"
   top: "conv5_3_p"
-  name: "relu5_3_p"
-  type: RELU
 }
-
-layers {
+layer {
+  name: "pool5_p"
+  type: "Pooling"
   bottom: "conv5_3_p"
   top: "pool5_p"
-  name: "pool5_p"
-  type: POOLING
   pooling_param {
     pool: MAX
     kernel_size: 2

--- a/nets/tracker-vgg16.prototxt
+++ b/nets/tracker-vgg16.prototxt
@@ -27,35 +27,71 @@ layer {
   type: "Convolution"
   bottom: "target"
   top: "conv1_1"
+  param {
+    lr_mult: 0
+    decay_mult: 1
+  }
+  param {
+    lr_mult: 0
+    decay_mult: 0
+  }
   convolution_param {
     num_output: 64
     pad: 1
     kernel_size: 3
+    weight_filler {
+      type: "gaussian"
+      std: 0.01
+    }
+    bias_filler {
+      type: "constant"
+      value: 0
+    }
   }
 }
+
 layer {
   name: "relu1_1"
   type: "ReLU"
   bottom: "conv1_1"
   top: "conv1_1"
 }
+
 layer {
   name: "conv1_2"
   type: "Convolution"
   bottom: "conv1_1"
   top: "conv1_2"
+  param {
+    lr_mult: 0
+    decay_mult: 1
+  }
+  param {
+    lr_mult: 0
+    decay_mult: 0
+  }
   convolution_param {
     num_output: 64
     pad: 1
     kernel_size: 3
+    weight_filler {
+      type: "gaussian"
+      std: 0.01
+    }
+    bias_filler {
+      type: "constant"
+      value: 0
+    }
   }
 }
+
 layer {
   name: "relu1_2"
   type: "ReLU"
   bottom: "conv1_2"
   top: "conv1_2"
 }
+
 layer {
   name: "pool1"
   type: "Pooling"
@@ -67,40 +103,77 @@ layer {
     stride: 2
   }
 }
+
 layer {
   name: "conv2_1"
   type: "Convolution"
   bottom: "pool1"
   top: "conv2_1"
+  param {
+    lr_mult: 0
+    decay_mult: 1
+  }
+  param {
+    lr_mult: 0
+    decay_mult: 0
+  }
   convolution_param {
     num_output: 128
     pad: 1
     kernel_size: 3
+    weight_filler {
+      type: "gaussian"
+      std: 0.01
+    }
+    bias_filler {
+      type: "constant"
+      value: 0
+    }
   }
 }
+
 layer {
   name: "relu2_1"
   type: "ReLU"
   bottom: "conv2_1"
   top: "conv2_1"
 }
+
 layer {
   name: "conv2_2"
   type: "Convolution"
   bottom: "conv2_1"
   top: "conv2_2"
+  param {
+    lr_mult: 0
+    decay_mult: 1
+  }
+  param {
+    lr_mult: 0
+    decay_mult: 0
+  }
   convolution_param {
     num_output: 128
     pad: 1
     kernel_size: 3
+    weight_filler {
+      type: "gaussian"
+      std: 0.01
+    }
+    bias_filler {
+      type: "constant"
+      value: 0
+    }
   }
 }
+
 layer {
   name: "relu2_2"
   type: "ReLU"
   bottom: "conv2_2"
   top: "conv2_2"
 }
+
 layer {
   name: "pool2"
   type: "Pooling"
@@ -112,57 +185,112 @@ layer {
     stride: 2
   }
 }
+
 layer {
   name: "conv3_1"
   type: "Convolution"
   bottom: "pool2"
   top: "conv3_1"
+  param {
+    lr_mult: 0
+    decay_mult: 1
+  }
+  param {
+    lr_mult: 0
+    decay_mult: 0
+  }
   convolution_param {
     num_output: 256
     pad: 1
     kernel_size: 3
+    weight_filler {
+      type: "gaussian"
+      std: 0.01
+    }
+    bias_filler {
+      type: "constant"
+      value: 0
+    }
   }
 }
+
 layer {
   name: "relu3_1"
   type: "ReLU"
   bottom: "conv3_1"
   top: "conv3_1"
 }
+
 layer {
   name: "conv3_2"
   type: "Convolution"
   bottom: "conv3_1"
   top: "conv3_2"
+  param {
+    lr_mult: 0
+    decay_mult: 1
+  }
+  param {
+    lr_mult: 0
+    decay_mult: 0
+  }
   convolution_param {
     num_output: 256
     pad: 1
     kernel_size: 3
+    weight_filler {
+      type: "gaussian"
+      std: 0.01
+    }
+    bias_filler {
+      type: "constant"
+      value: 0
+    }
   }
 }
+
 layer {
   name: "relu3_2"
   type: "ReLU"
   bottom: "conv3_2"
   top: "conv3_2"
 }
+
 layer {
   name: "conv3_3"
   type: "Convolution"
   bottom: "conv3_2"
   top: "conv3_3"
+  param {
+    lr_mult: 0
+    decay_mult: 1
+  }
+  param {
+    lr_mult: 0
+    decay_mult: 0
+  }
   convolution_param {
     num_output: 256
     pad: 1
     kernel_size: 3
+    weight_filler {
+      type: "gaussian"
+      std: 0.01
+    }
+    bias_filler {
+      type: "constant"
+      value: 0
+    }
   }
 }
+
 layer {
   name: "relu3_3"
   type: "ReLU"
   bottom: "conv3_3"
   top: "conv3_3"
 }
+
 layer {
   name: "pool3"
   type: "Pooling"
@@ -174,57 +302,112 @@ layer {
     stride: 2
   }
 }
+
 layer {
   name: "conv4_1"
   type: "Convolution"
   bottom: "pool3"
   top: "conv4_1"
+  param {
+    lr_mult: 0
+    decay_mult: 1
+  }
+  param {
+    lr_mult: 0
+    decay_mult: 0
+  }
   convolution_param {
     num_output: 512
     pad: 1
     kernel_size: 3
+    weight_filler {
+      type: "gaussian"
+      std: 0.01
+    }
+    bias_filler {
+      type: "constant"
+      value: 0
+    }
   }
 }
+
 layer {
   name: "relu4_1"
   type: "ReLU"
   bottom: "conv4_1"
   top: "conv4_1"
 }
+
 layer {
   name: "conv4_2"
   type: "Convolution"
   bottom: "conv4_1"
   top: "conv4_2"
+  param {
+    lr_mult: 0
+    decay_mult: 1
+  }
+  param {
+    lr_mult: 0
+    decay_mult: 0
+  }
   convolution_param {
     num_output: 512
     pad: 1
     kernel_size: 3
+    weight_filler {
+      type: "gaussian"
+      std: 0.01
+    }
+    bias_filler {
+      type: "constant"
+      value: 0
+    }
   }
 }
+
 layer {
   name: "relu4_2"
   type: "ReLU"
   bottom: "conv4_2"
   top: "conv4_2"
 }
+
 layer {
   name: "conv4_3"
   type: "Convolution"
   bottom: "conv4_2"
   top: "conv4_3"
+  param {
+    lr_mult: 0
+    decay_mult: 1
+  }
+  param {
+    lr_mult: 0
+    decay_mult: 0
+  }
   convolution_param {
     num_output: 512
     pad: 1
     kernel_size: 3
+    weight_filler {
+      type: "gaussian"
+      std: 0.01
+    }
+    bias_filler {
+      type: "constant"
+      value: 0
+    }
   }
 }
+
 layer {
   name: "relu4_3"
   type: "ReLU"
   bottom: "conv4_3"
   top: "conv4_3"
 }
+
 layer {
   name: "pool4"
   type: "Pooling"
@@ -236,32 +419,67 @@ layer {
     stride: 2
   }
 }
+
 layer {
   name: "conv5_1"
   type: "Convolution"
   bottom: "pool4"
   top: "conv5_1"
+  param {
+    lr_mult: 0
+    decay_mult: 1
+  }
+  param {
+    lr_mult: 0
+    decay_mult: 0
+  }
   convolution_param {
     num_output: 512
     pad: 1
     kernel_size: 3
+    weight_filler {
+      type: "gaussian"
+      std: 0.01
+    }
+    bias_filler {
+      type: "constant"
+      value: 0
+    }
   }
 }
+
 layer {
   name: "relu5_1"
   type: "ReLU"
   bottom: "conv5_1"
   top: "conv5_1"
 }
+
 layer {
   name: "conv5_2"
   type: "Convolution"
   bottom: "conv5_1"
   top: "conv5_2"
+  param {
+    lr_mult: 0
+    decay_mult: 1
+  }
+  param {
+    lr_mult: 0
+    decay_mult: 0
+  }
   convolution_param {
     num_output: 512
     pad: 1
     kernel_size: 3
+    weight_filler {
+      type: "gaussian"
+      std: 0.01
+    }
+    bias_filler {
+      type: "constant"
+      value: 0
+    }
   }
 }
 layer {
@@ -275,10 +493,26 @@ layer {
   type: "Convolution"
   bottom: "conv5_2"
   top: "conv5_3"
+  param {
+    lr_mult: 0
+    decay_mult: 1
+  }
+  param {
+    lr_mult: 0
+    decay_mult: 0
+  }
   convolution_param {
     num_output: 512
     pad: 1
     kernel_size: 3
+    weight_filler {
+      type: "gaussian"
+      std: 0.01
+    }
+    bias_filler {
+      type: "constant"
+      value: 0
+    }
   }
 }
 layer {
@@ -303,10 +537,26 @@ layer {
   type: "Convolution"
   bottom: "image"
   top: "conv1_1_p"
+  param {
+    lr_mult: 0
+    decay_mult: 1
+  }
+  param {
+    lr_mult: 0
+    decay_mult: 0
+  }
   convolution_param {
     num_output: 64
     pad: 1
     kernel_size: 3
+    weight_filler {
+      type: "gaussian"
+      std: 0.01
+    }
+    bias_filler {
+      type: "constant"
+      value: 0
+    }
   }
 }
 layer {
@@ -320,10 +570,26 @@ layer {
   type: "Convolution"
   bottom: "conv1_1_p"
   top: "conv1_2_p"
+  param {
+    lr_mult: 0
+    decay_mult: 1
+  }
+  param {
+    lr_mult: 0
+    decay_mult: 0
+  }
   convolution_param {
     num_output: 64
     pad: 1
     kernel_size: 3
+    weight_filler {
+      type: "gaussian"
+      std: 0.01
+    }
+    bias_filler {
+      type: "constant"
+      value: 0
+    }
   }
 }
 layer {
@@ -348,10 +614,26 @@ layer {
   type: "Convolution"
   bottom: "pool1_p"
   top: "conv2_1_p"
+  param {
+    lr_mult: 0
+    decay_mult: 1
+  }
+  param {
+    lr_mult: 0
+    decay_mult: 0
+  }
   convolution_param {
     num_output: 128
     pad: 1
     kernel_size: 3
+    weight_filler {
+      type: "gaussian"
+      std: 0.01
+    }
+    bias_filler {
+      type: "constant"
+      value: 0
+    }
   }
 }
 layer {
@@ -365,10 +647,26 @@ layer {
   type: "Convolution"
   bottom: "conv2_1_p"
   top: "conv2_2_p"
+  param {
+    lr_mult: 0
+    decay_mult: 1
+  }
+  param {
+    lr_mult: 0
+    decay_mult: 0
+  }
   convolution_param {
     num_output: 128
     pad: 1
     kernel_size: 3
+    weight_filler {
+      type: "gaussian"
+      std: 0.01
+    }
+    bias_filler {
+      type: "constant"
+      value: 0
+    }
   }
 }
 layer {
@@ -393,10 +691,26 @@ layer {
   type: "Convolution"
   bottom: "pool2_p"
   top: "conv3_1_p"
+  param {
+    lr_mult: 0
+    decay_mult: 1
+  }
+  param {
+    lr_mult: 0
+    decay_mult: 0
+  }
   convolution_param {
     num_output: 256
     pad: 1
     kernel_size: 3
+    weight_filler {
+      type: "gaussian"
+      std: 0.01
+    }
+    bias_filler {
+      type: "constant"
+      value: 0
+    }
   }
 }
 layer {
@@ -410,10 +724,26 @@ layer {
   type: "Convolution"
   bottom: "conv3_1_p"
   top: "conv3_2_p"
+  param {
+    lr_mult: 0
+    decay_mult: 1
+  }
+  param {
+    lr_mult: 0
+    decay_mult: 0
+  }
   convolution_param {
     num_output: 256
     pad: 1
     kernel_size: 3
+    weight_filler {
+      type: "gaussian"
+      std: 0.01
+    }
+    bias_filler {
+      type: "constant"
+      value: 0
+    }
   }
 }
 layer {
@@ -427,10 +757,26 @@ layer {
   type: "Convolution"
   bottom: "conv3_2_p"
   top: "conv3_3_p"
+  param {
+    lr_mult: 0
+    decay_mult: 1
+  }
+  param {
+    lr_mult: 0
+    decay_mult: 0
+  }
   convolution_param {
     num_output: 256
     pad: 1
     kernel_size: 3
+    weight_filler {
+      type: "gaussian"
+      std: 0.01
+    }
+    bias_filler {
+      type: "constant"
+      value: 0
+    }
   }
 }
 layer {
@@ -455,10 +801,26 @@ layer {
   type: "Convolution"
   bottom: "pool3_p"
   top: "conv4_1_p"
+  param {
+    lr_mult: 0
+    decay_mult: 1
+  }
+  param {
+    lr_mult: 0
+    decay_mult: 0
+  }
   convolution_param {
     num_output: 512
     pad: 1
     kernel_size: 3
+    weight_filler {
+      type: "gaussian"
+      std: 0.01
+    }
+    bias_filler {
+      type: "constant"
+      value: 0
+    }
   }
 }
 layer {
@@ -472,10 +834,26 @@ layer {
   type: "Convolution"
   bottom: "conv4_1_p"
   top: "conv4_2_p"
+  param {
+    lr_mult: 0
+    decay_mult: 1
+  }
+  param {
+    lr_mult: 0
+    decay_mult: 0
+  }
   convolution_param {
     num_output: 512
     pad: 1
     kernel_size: 3
+    weight_filler {
+      type: "gaussian"
+      std: 0.01
+    }
+    bias_filler {
+      type: "constant"
+      value: 0
+    }
   }
 }
 layer {
@@ -489,10 +867,26 @@ layer {
   type: "Convolution"
   bottom: "conv4_2_p"
   top: "conv4_3_p"
+  param {
+    lr_mult: 0
+    decay_mult: 1
+  }
+  param {
+    lr_mult: 0
+    decay_mult: 0
+  }
   convolution_param {
     num_output: 512
     pad: 1
     kernel_size: 3
+    weight_filler {
+      type: "gaussian"
+      std: 0.01
+    }
+    bias_filler {
+      type: "constant"
+      value: 0
+    }
   }
 }
 layer {
@@ -517,10 +911,26 @@ layer {
   type: "Convolution"
   bottom: "pool4_p"
   top: "conv5_1_p"
+  param {
+    lr_mult: 0
+    decay_mult: 1
+  }
+  param {
+    lr_mult: 0
+    decay_mult: 0
+  }
   convolution_param {
     num_output: 512
     pad: 1
     kernel_size: 3
+    weight_filler {
+      type: "gaussian"
+      std: 0.01
+    }
+    bias_filler {
+      type: "constant"
+      value: 0
+    }
   }
 }
 layer {
@@ -534,10 +944,26 @@ layer {
   type: "Convolution"
   bottom: "conv5_1_p"
   top: "conv5_2_p"
+  param {
+    lr_mult: 0
+    decay_mult: 1
+  }
+  param {
+    lr_mult: 0
+    decay_mult: 0
+  }
   convolution_param {
     num_output: 512
     pad: 1
     kernel_size: 3
+    weight_filler {
+      type: "gaussian"
+      std: 0.01
+    }
+    bias_filler {
+      type: "constant"
+      value: 0
+    }
   }
 }
 layer {
@@ -551,10 +977,26 @@ layer {
   type: "Convolution"
   bottom: "conv5_2_p"
   top: "conv5_3_p"
+  param {
+    lr_mult: 0
+    decay_mult: 1
+  }
+  param {
+    lr_mult: 0
+    decay_mult: 0
+  }
   convolution_param {
     num_output: 512
     pad: 1
     kernel_size: 3
+    weight_filler {
+      type: "gaussian"
+      std: 0.01
+    }
+    bias_filler {
+      type: "constant"
+      value: 0
+    }
   }
 }
 layer {

--- a/nets/tracker-vgg16.prototxt
+++ b/nets/tracker-vgg16.prototxt
@@ -1,4 +1,4 @@
-name: "VGG_ILSVRC_16_layers"
+name: "GOTURN_VGG_ILSVRC_16_layers"
 
 input: "target"
 input: "image"
@@ -328,18 +328,6 @@ layers {
     stride: 2
   }
 }
-
-layers {
-  bottom: "pool5"
-  top: "fc6"
-  name: "fc6"
-  type: INNER_PRODUCT
-  inner_product_param {
-    num_output: 4096
-  }
-}
-
-
 
 layers {
   bottom: "image"

--- a/nets/tracker-vgg16.prototxt.old
+++ b/nets/tracker-vgg16.prototxt.old
@@ -5,16 +5,16 @@ input: "image"
 input: "bbox"
 
 #target
-input_dim: 1
+input_dim: 10
 input_dim: 3
-input_dim: 227
-input_dim: 227
+input_dim: 224
+input_dim: 224
 
 #image
-input_dim: 1
+input_dim: 10
 input_dim: 3
-input_dim: 227
-input_dim: 227
+input_dim: 224
+input_dim: 224
 
 #bbox
 input_dim: 1
@@ -22,552 +22,613 @@ input_dim: 4
 input_dim: 1
 input_dim: 1
 
-layer {
-  name: "conv1_1"
-  type: "Convolution"
+layers {
   bottom: "target"
   top: "conv1_1"
+  name: "conv1_1"
+  type: CONVOLUTION
   convolution_param {
     num_output: 64
     pad: 1
     kernel_size: 3
   }
 }
-layer {
-  name: "relu1_1"
-  type: "ReLU"
+
+layers {
   bottom: "conv1_1"
   top: "conv1_1"
+  name: "relu1_1"
+  type: RELU
 }
-layer {
-  name: "conv1_2"
-  type: "Convolution"
+
+layers {
   bottom: "conv1_1"
   top: "conv1_2"
+  name: "conv1_2"
+  type: CONVOLUTION
   convolution_param {
     num_output: 64
     pad: 1
     kernel_size: 3
   }
 }
-layer {
-  name: "relu1_2"
-  type: "ReLU"
+
+layers {
   bottom: "conv1_2"
   top: "conv1_2"
+  name: "relu1_2"
+  type: RELU
 }
-layer {
-  name: "pool1"
-  type: "Pooling"
+
+layers {
   bottom: "conv1_2"
   top: "pool1"
+  name: "pool1"
+  type: POOLING
   pooling_param {
     pool: MAX
     kernel_size: 2
     stride: 2
   }
 }
-layer {
-  name: "conv2_1"
-  type: "Convolution"
+
+layers {
   bottom: "pool1"
   top: "conv2_1"
+  name: "conv2_1"
+  type: CONVOLUTION
   convolution_param {
     num_output: 128
     pad: 1
     kernel_size: 3
   }
 }
-layer {
-  name: "relu2_1"
-  type: "ReLU"
+
+layers {
   bottom: "conv2_1"
   top: "conv2_1"
+  name: "relu2_1"
+  type: RELU
 }
-layer {
-  name: "conv2_2"
-  type: "Convolution"
+
+layers {
   bottom: "conv2_1"
   top: "conv2_2"
+  name: "conv2_2"
+  type: CONVOLUTION
   convolution_param {
     num_output: 128
     pad: 1
     kernel_size: 3
   }
 }
-layer {
-  name: "relu2_2"
-  type: "ReLU"
+
+layers {
   bottom: "conv2_2"
   top: "conv2_2"
+  name: "relu2_2"
+  type: RELU
 }
-layer {
-  name: "pool2"
-  type: "Pooling"
+
+layers {
   bottom: "conv2_2"
   top: "pool2"
+  name: "pool2"
+  type: POOLING
   pooling_param {
     pool: MAX
     kernel_size: 2
     stride: 2
   }
 }
-layer {
-  name: "conv3_1"
-  type: "Convolution"
+
+layers {
   bottom: "pool2"
   top: "conv3_1"
+  name: "conv3_1"
+  type: CONVOLUTION
   convolution_param {
     num_output: 256
     pad: 1
     kernel_size: 3
   }
 }
-layer {
-  name: "relu3_1"
-  type: "ReLU"
+
+layers {
   bottom: "conv3_1"
   top: "conv3_1"
+  name: "relu3_1"
+  type: RELU
 }
-layer {
-  name: "conv3_2"
-  type: "Convolution"
+
+layers {
   bottom: "conv3_1"
   top: "conv3_2"
+  name: "conv3_2"
+  type: CONVOLUTION
   convolution_param {
     num_output: 256
     pad: 1
     kernel_size: 3
   }
 }
-layer {
-  name: "relu3_2"
-  type: "ReLU"
+
+layers {
   bottom: "conv3_2"
   top: "conv3_2"
+  name: "relu3_2"
+  type: RELU
 }
-layer {
-  name: "conv3_3"
-  type: "Convolution"
+
+layers {
   bottom: "conv3_2"
   top: "conv3_3"
+  name: "conv3_3"
+  type: CONVOLUTION
   convolution_param {
     num_output: 256
     pad: 1
     kernel_size: 3
   }
 }
-layer {
-  name: "relu3_3"
-  type: "ReLU"
+
+layers {
   bottom: "conv3_3"
   top: "conv3_3"
+  name: "relu3_3"
+  type: RELU
 }
-layer {
-  name: "pool3"
-  type: "Pooling"
+
+layers {
   bottom: "conv3_3"
   top: "pool3"
+  name: "pool3"
+  type: POOLING
   pooling_param {
     pool: MAX
     kernel_size: 2
     stride: 2
   }
 }
-layer {
-  name: "conv4_1"
-  type: "Convolution"
+
+layers {
   bottom: "pool3"
   top: "conv4_1"
+  name: "conv4_1"
+  type: CONVOLUTION
   convolution_param {
     num_output: 512
     pad: 1
     kernel_size: 3
   }
 }
-layer {
-  name: "relu4_1"
-  type: "ReLU"
+
+layers {
   bottom: "conv4_1"
   top: "conv4_1"
+  name: "relu4_1"
+  type: RELU
 }
-layer {
-  name: "conv4_2"
-  type: "Convolution"
+
+layers {
   bottom: "conv4_1"
   top: "conv4_2"
+  name: "conv4_2"
+  type: CONVOLUTION
   convolution_param {
     num_output: 512
     pad: 1
     kernel_size: 3
   }
 }
-layer {
-  name: "relu4_2"
-  type: "ReLU"
+
+layers {
   bottom: "conv4_2"
   top: "conv4_2"
+  name: "relu4_2"
+  type: RELU
 }
-layer {
-  name: "conv4_3"
-  type: "Convolution"
+
+layers {
   bottom: "conv4_2"
   top: "conv4_3"
+  name: "conv4_3"
+  type: CONVOLUTION
   convolution_param {
     num_output: 512
     pad: 1
     kernel_size: 3
   }
 }
-layer {
-  name: "relu4_3"
-  type: "ReLU"
+
+layers {
   bottom: "conv4_3"
   top: "conv4_3"
+  name: "relu4_3"
+  type: RELU
 }
-layer {
-  name: "pool4"
-  type: "Pooling"
+
+layers {
   bottom: "conv4_3"
   top: "pool4"
+  name: "pool4"
+  type: POOLING
   pooling_param {
     pool: MAX
     kernel_size: 2
     stride: 2
   }
 }
-layer {
-  name: "conv5_1"
-  type: "Convolution"
+
+layers {
   bottom: "pool4"
   top: "conv5_1"
+  name: "conv5_1"
+  type: CONVOLUTION
   convolution_param {
     num_output: 512
     pad: 1
     kernel_size: 3
   }
 }
-layer {
-  name: "relu5_1"
-  type: "ReLU"
+
+layers {
   bottom: "conv5_1"
   top: "conv5_1"
+  name: "relu5_1"
+  type: RELU
 }
-layer {
-  name: "conv5_2"
-  type: "Convolution"
+
+layers {
   bottom: "conv5_1"
   top: "conv5_2"
+  name: "conv5_2"
+  type: CONVOLUTION
   convolution_param {
     num_output: 512
     pad: 1
     kernel_size: 3
   }
 }
-layer {
-  name: "relu5_2"
-  type: "ReLU"
+
+layers {
   bottom: "conv5_2"
   top: "conv5_2"
+  name: "relu5_2"
+  type: RELU
 }
-layer {
-  name: "conv5_3"
-  type: "Convolution"
+
+layers {
   bottom: "conv5_2"
   top: "conv5_3"
+  name: "conv5_3"
+  type: CONVOLUTION
   convolution_param {
     num_output: 512
     pad: 1
     kernel_size: 3
   }
 }
-layer {
-  name: "relu5_3"
-  type: "ReLU"
+
+layers {
   bottom: "conv5_3"
   top: "conv5_3"
+  name: "relu5_3"
+  type: RELU
 }
-layer {
-  name: "pool5"
-  type: "Pooling"
+
+layers {
   bottom: "conv5_3"
   top: "pool5"
+  name: "pool5"
+  type: POOLING
   pooling_param {
     pool: MAX
     kernel_size: 2
     stride: 2
   }
 }
-layer {
-  name: "conv1_1_p"
-  type: "Convolution"
+
+layers {
   bottom: "image"
   top: "conv1_1_p"
+  name: "conv1_1_p"
+  type: CONVOLUTION
   convolution_param {
     num_output: 64
     pad: 1
     kernel_size: 3
   }
 }
-layer {
-  name: "relu1_1_p"
-  type: "ReLU"
+
+layers {
   bottom: "conv1_1_p"
   top: "conv1_1_p"
+  name: "relu1_1_p"
+  type: RELU
 }
-layer {
-  name: "conv1_2_p"
-  type: "Convolution"
+
+layers {
   bottom: "conv1_1_p"
   top: "conv1_2_p"
+  name: "conv1_2_p"
+  type: CONVOLUTION
   convolution_param {
     num_output: 64
     pad: 1
     kernel_size: 3
   }
 }
-layer {
-  name: "relu1_2_p"
-  type: "ReLU"
+
+layers {
   bottom: "conv1_2_p"
   top: "conv1_2_p"
+  name: "relu1_2_p"
+  type: RELU
 }
-layer {
-  name: "pool1_p"
-  type: "Pooling"
+
+layers {
   bottom: "conv1_2_p"
   top: "pool1_p"
+  name: "pool1_p"
+  type: POOLING
   pooling_param {
     pool: MAX
     kernel_size: 2
     stride: 2
   }
 }
-layer {
-  name: "conv2_1_p"
-  type: "Convolution"
+
+layers {
   bottom: "pool1_p"
   top: "conv2_1_p"
+  name: "conv2_1_p"
+  type: CONVOLUTION
   convolution_param {
     num_output: 128
     pad: 1
     kernel_size: 3
   }
 }
-layer {
-  name: "relu2_1_p"
-  type: "ReLU"
+
+layers {
   bottom: "conv2_1_p"
   top: "conv2_1_p"
+  name: "relu2_1_p"
+  type: RELU
 }
-layer {
-  name: "conv2_2_p"
-  type: "Convolution"
+
+layers {
   bottom: "conv2_1_p"
   top: "conv2_2_p"
+  name: "conv2_2_p"
+  type: CONVOLUTION
   convolution_param {
     num_output: 128
     pad: 1
     kernel_size: 3
   }
 }
-layer {
-  name: "relu2_2_p"
-  type: "ReLU"
+
+layers {
   bottom: "conv2_2_p"
   top: "conv2_2_p"
+  name: "relu2_2_p"
+  type: RELU
 }
-layer {
-  name: "pool2_p"
-  type: "Pooling"
+
+layers {
   bottom: "conv2_2_p"
   top: "pool2_p"
+  name: "pool2_p"
+  type: POOLING
   pooling_param {
     pool: MAX
     kernel_size: 2
     stride: 2
   }
 }
-layer {
-  name: "conv3_1_p"
-  type: "Convolution"
+
+layers {
   bottom: "pool2_p"
   top: "conv3_1_p"
+  name: "conv3_1_p"
+  type: CONVOLUTION
   convolution_param {
     num_output: 256
     pad: 1
     kernel_size: 3
   }
 }
-layer {
-  name: "relu3_1_p"
-  type: "ReLU"
+
+layers {
   bottom: "conv3_1_p"
   top: "conv3_1_p"
+  name: "relu3_1_p"
+  type: RELU
 }
-layer {
-  name: "conv3_2_p"
-  type: "Convolution"
+
+layers {
   bottom: "conv3_1_p"
   top: "conv3_2_p"
+  name: "conv3_2_p"
+  type: CONVOLUTION
   convolution_param {
     num_output: 256
     pad: 1
     kernel_size: 3
   }
 }
-layer {
-  name: "relu3_2_p"
-  type: "ReLU"
+
+layers {
   bottom: "conv3_2_p"
   top: "conv3_2_p"
+  name: "relu3_2_p"
+  type: RELU
 }
-layer {
-  name: "conv3_3_p"
-  type: "Convolution"
+
+layers {
   bottom: "conv3_2_p"
   top: "conv3_3_p"
+  name: "conv3_3_p"
+  type: CONVOLUTION
   convolution_param {
     num_output: 256
     pad: 1
     kernel_size: 3
   }
 }
-layer {
-  name: "relu3_3_p"
-  type: "ReLU"
+
+layers {
   bottom: "conv3_3_p"
   top: "conv3_3_p"
+  name: "relu3_3_p"
+  type: RELU
 }
-layer {
-  name: "pool3_p"
-  type: "Pooling"
+
+layers {
   bottom: "conv3_3_p"
   top: "pool3_p"
+  name: "pool3_p"
+  type: POOLING
   pooling_param {
     pool: MAX
     kernel_size: 2
     stride: 2
   }
 }
-layer {
-  name: "conv4_1_p"
-  type: "Convolution"
+
+layers {
   bottom: "pool3_p"
   top: "conv4_1_p"
+  name: "conv4_1_p"
+  type: CONVOLUTION
   convolution_param {
     num_output: 512
     pad: 1
     kernel_size: 3
   }
 }
-layer {
-  name: "relu4_1_p"
-  type: "ReLU"
+
+layers {
   bottom: "conv4_1_p"
   top: "conv4_1_p"
+  name: "relu4_1_p"
+  type: RELU
 }
-layer {
-  name: "conv4_2_p"
-  type: "Convolution"
+
+layers {
   bottom: "conv4_1_p"
   top: "conv4_2_p"
+  name: "conv4_2_p"
+  type: CONVOLUTION
   convolution_param {
     num_output: 512
     pad: 1
     kernel_size: 3
   }
 }
-layer {
-  name: "relu4_2_p"
-  type: "ReLU"
+
+layers {
   bottom: "conv4_2_p"
   top: "conv4_2_p"
+  name: "relu4_2_p"
+  type: RELU
 }
-layer {
-  name: "conv4_3_p"
-  type: "Convolution"
+
+layers {
   bottom: "conv4_2_p"
   top: "conv4_3_p"
+  name: "conv4_3_p"
+  type: CONVOLUTION
   convolution_param {
     num_output: 512
     pad: 1
     kernel_size: 3
   }
 }
-layer {
-  name: "relu4_3_p"
-  type: "ReLU"
+
+layers {
   bottom: "conv4_3_p"
   top: "conv4_3_p"
+  name: "relu4_3_p"
+  type: RELU
 }
-layer {
-  name: "pool4_p"
-  type: "Pooling"
+
+layers {
   bottom: "conv4_3_p"
   top: "pool4_p"
+  name: "pool4_p"
+  type: POOLING
   pooling_param {
     pool: MAX
     kernel_size: 2
     stride: 2
   }
 }
-layer {
-  name: "conv5_1_p"
-  type: "Convolution"
+
+layers {
   bottom: "pool4_p"
   top: "conv5_1_p"
+  name: "conv5_1_p"
+  type: CONVOLUTION
   convolution_param {
     num_output: 512
     pad: 1
     kernel_size: 3
   }
 }
-layer {
-  name: "relu5_1_p"
-  type: "ReLU"
+
+layers {
   bottom: "conv5_1_p"
   top: "conv5_1_p"
+  name: "relu5_1_p"
+  type: RELU
 }
-layer {
-  name: "conv5_2_p"
-  type: "Convolution"
+
+layers {
   bottom: "conv5_1_p"
   top: "conv5_2_p"
+  name: "conv5_2_p"
+  type: CONVOLUTION
   convolution_param {
     num_output: 512
     pad: 1
     kernel_size: 3
   }
 }
-layer {
-  name: "relu5_2_p"
-  type: "ReLU"
+
+layers {
   bottom: "conv5_2_p"
   top: "conv5_2_p"
+  name: "relu5_2_p"
+  type: RELU
 }
-layer {
-  name: "conv5_3_p"
-  type: "Convolution"
+
+layers {
   bottom: "conv5_2_p"
   top: "conv5_3_p"
+  name: "conv5_3_p"
+  type: CONVOLUTION
   convolution_param {
     num_output: 512
     pad: 1
     kernel_size: 3
   }
 }
-layer {
-  name: "relu5_3_p"
-  type: "ReLU"
+
+layers {
   bottom: "conv5_3_p"
   top: "conv5_3_p"
+  name: "relu5_3_p"
+  type: RELU
 }
-layer {
-  name: "pool5_p"
-  type: "Pooling"
+
+layers {
   bottom: "conv5_3_p"
   top: "pool5_p"
+  name: "pool5_p"
+  type: POOLING
   pooling_param {
     pool: MAX
     kernel_size: 2
@@ -777,5 +838,34 @@ layer {
   loss_weight: 1
   reduction_param {
     operation: 2
+  }
+}
+-----------------
+
+layer {
+  name: "input"
+  type: "Input"
+  top: "target"
+  top: "image"
+  top: "bbox"
+  input_param {
+    shape {
+      dim: 10
+      dim: 3
+      dim: 224
+      dim: 224
+    }
+    shape {
+      dim: 10
+      dim: 3
+      dim: 224
+      dim: 224
+    }
+    shape {
+      dim: 1
+      dim: 4
+      dim: 1
+      dim: 1
+    }
   }
 }

--- a/train_tracker.sh
+++ b/train_tracker.sh
@@ -1,7 +1,7 @@
-IMAGENET_FOLDER='/media/nrupatunga/LAPTOP_BACKUP/Datasets/ILSVRC2014'
-ALOV_FOLDER='/media/nrupatunga/LAPTOP_BACKUP/Datasets/ALOV'
-INIT_CAFFEMODEL='./nets/tracker_init.caffemodel'
-TRACKER_PROTO='./nets/tracker.prototxt'
+IMAGENET_FOLDER='/home/virendra/dlcv/imagenet/new_loc'
+ALOV_FOLDER='/home/virendra/dlcv/alov'
+INIT_CAFFEMODEL='./nets/VGG_ILSVRC_16_layers.caffemodel'
+TRACKER_PROTO='./nets/tracker-vgg16.prototxt'
 SOLVER_PROTO='./nets/solver.prototxt'
 
 python -m goturn.train.train \


### PR DESCRIPTION
This pull request replaces CaffeNet with VGG-16 as a feature extractor.
A pre-trained caffe VGG16 model is used.
https://gist.github.com/ksimonyan/211839e770f7b538e2d8#file-readme-md 